### PR TITLE
Remove unneeded config from Google OAuth

### DIFF
--- a/client/src/screens/index.tsx
+++ b/client/src/screens/index.tsx
@@ -25,7 +25,6 @@ export default function Index() {
 
   const [request, response, promptAsync] = Google.useAuthRequest({
     iosClientId: GOOGLE_IOS_ID,
-    responseType: "id_token",
     scopes: ["profile", "email"],
   });
 


### PR DESCRIPTION
## Summary
Remove line of code that prevented from doing Google OAuth

## Key Change
- Remove `responseType` from config from function to allow proper Google sign in functionality